### PR TITLE
feat: add jsx-key rule to detect missing key on jsx elements

### DIFF
--- a/rules/react.js
+++ b/rules/react.js
@@ -45,6 +45,8 @@ module.exports = {
     'react/jsx-indent': ['error', 2, { indentLogicalExpressions: true }],
     // Validate props indentation in JSX.
     'react/jsx-indent-props': ['error', 2],
+    // Detect missing key prop.
+    'react/jsx-key': 'error',
     // Limit maximum of props on a single line in JSX when the element is multiline.
     'react/jsx-max-props-per-line': ['error', { when: 'multiline' }],
     // Prevent duplicate props in JSX.


### PR DESCRIPTION
Any reason not to turn this rule on?

https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/jsx-key.md

I noticed this while debugging a different PR and noticing react warnings in the console.