### PR TITLE
Update import.js, loosen prefer-default-export

### DIFF
--- a/rules/import.js
+++ b/rules/import.js
@@ -110,7 +110,7 @@ module.exports = {
     // Enforce a convention in the order of require() / import statements.
     'import/order': ['error', { groups: [['builtin', 'external', 'internal']] }],
     // When there is only a single export from a module, prefer using default export over named export.
-    'import/prefer-default-export': 'error',
+    'import/prefer-default-export': 'off',
     // Warn if a module could be mistakenly parsed as a script by a consumer leveraging Unambiguous
     // JavaScript Grammar to determine correct parsing goal.
     'import/unambiguous': 'off',


### PR DESCRIPTION
After discussing w/ Background team, decided that we like being able to create files that are named after concepts (i.e. a model) that expose just a single function not named after the model (i.e. createModel). Loosening the rule to support this desire.